### PR TITLE
add parameters min/max key, height

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ A number of options are available to customize the way the keys are drawn.
 
 - `keysAreRounded` - set to `false` if you want rectangular keys
 - `keyWidth` - specify the width of each white key. Default is `24`
+- `keyHeight` - specify the height of each white key. Default is `140`
 - `blackKeyWidth` - specify the width of each black key. Default is `14`
 - `blackKeyHeightRatio` - modify the height of black keys, expressed as a percentage of white key height. Valid range is 5% to 100%, expressed as a float (`0.05` to `1.0`)
 - `spacing` - specify a visual gap between white keys. Even values work best. Default is `0`
@@ -137,6 +138,7 @@ const keys = new PianoKeys.Keyboard(document.getElementById('keys'), {
     whiteKeyHighlightFill: '#D1D3D4',
     keysAreRounded: false,
     keyWidth: 28,
+    keyHeight: 160,
     blackKeyWidth: 28,
     blackKeyHeightRatio: 0.55,
     spacing: 6,

--- a/index.d.ts
+++ b/index.d.ts
@@ -11,8 +11,35 @@ declare class Keyboard {
     setOnKeyClick(
         callback: (event: MouseEvent, keyInfo: { note: number, name: string }) => void
     ): void;
+    /**
+     * Set a custom callback function which is executed anytime a key is pressed.
+     *
+     * A data object is passed to the callback, containing note information:
+     *          { note: integer, name: string }
+     */
+    setOnKeyMouseDown(
+        callback: (event: MouseEvent, keyInfo: { note: number, name: string }) => void
+    ): void;
+    /**
+     * Set a custom callback function which is executed anytime a key is released.
+     *
+     * A data object is passed to the callback, containing note information:
+     *          { note: integer, name: string }
+     */
+    setOnKeyMouseUp(
+        callback: (event: MouseEvent, keyInfo: { note: number, name: string }) => void
+    ): void;
+
+
+
 }
 declare const PianoKeys: {
     Keyboard: typeof Keyboard;
 };
+
+declare namespace PianoKeys {
+    /** Instance type for the `Keyboard` class (usable as a type) */
+    export type Keyboard = InstanceType<typeof Keyboard>;
+}
+
 export default PianoKeys;

--- a/index.js
+++ b/index.js
@@ -32,6 +32,8 @@ function parseNoteName(noteName) {
             this.name = 'NoteNameParseError';
             this.noteName = noteName;
             this.onKeyClickedCallback = null;
+            this.onKeyMouseUpCallback = null;
+            this.onKeyMouseDownCallback = null;
         }
     }
 
@@ -157,7 +159,7 @@ class Keyboard {
         const whiteKeys = [];
         const blackKeys = [];
 
-        const keyHeight = 140;
+        const keyHeight = options.keyHeight != null ? options.keyHeight : 140;
         const keyWidth = options.keyWidth || 24;
         const blackKeyWidth = options.blackKeyWidth || 14;
         const blackKeyHeightRatio = options.blackKeyHeightRatio || 0.64286; // default height: 90
@@ -194,6 +196,25 @@ class Keyboard {
         for (const whiteKey of whiteKeys) svg.appendChild(whiteKey);
         for (const blackKey of blackKeys) svg.appendChild(blackKey);
 
+        // Mark central DO (C4) with a grey circle at the padded bottom of the SVG note
+        try {
+            const centralNote = parseNoteName('C4');
+            const centralKey = keys[centralNote];
+            if (centralKey) {
+                const kx = parseFloat(centralKey.getAttribute('x'));
+                const ky = parseFloat(centralKey.getAttribute('y'));
+                const kw = parseFloat(centralKey.getAttribute('width'));
+                const kh = parseFloat(centralKey.getAttribute('height'));
+                const radius = Math.min(8, kw / 6);
+                const cx = (kx + (kw / 2)).toString();
+                const cy = (ky + kh - (radius + 4)).toString();
+                const circle = createSvgElement('circle', { cx: cx, cy: cy, r: radius.toString(), fill: '#EEE', 'pointer-events': 'none' });
+                svg.appendChild(circle);
+            }
+        } catch (e) {
+            // ignore if parse fails or key not present
+        }
+
         container.appendChild(svg);
 
         // listeners added for all keys
@@ -205,6 +226,19 @@ class Keyboard {
                                                    name: midiNoteToName(e.target.id) });
                 }
             });
+            key.addEventListener("mouseup", (e) => {
+                if (this.onKeyMouseUpCallback) {
+                    this.onKeyMouseUpCallback(e, { note: e.target.id,
+                                                   name: midiNoteToName(e.target.id) });
+                }
+            });
+            key.addEventListener("mousedown", (e) => {
+                if (this.onKeyMouseDownCallback) {
+                    this.onKeyMouseDownCallback(e, { note: e.target.id,
+                                                   name: midiNoteToName(e.target.id) });
+                }
+            });            
+
         }
     }
 
@@ -232,6 +266,22 @@ class Keyboard {
     setOnKeyClick(callback) {
         if (typeof callback === 'function') {
             this.onKeyClickedCallback = callback;
+        } else {
+            throw new Error("Callback is not a function");
+        }
+    }
+
+    setOnKeyMouseDown(callback) {
+        if (typeof callback === 'function') {
+            this.onKeyMouseDownCallback = callback;
+        } else {
+            throw new Error("Callback is not a function");
+        }
+    }
+
+    setOnKeyMouseUp(callback) {
+        if (typeof callback === 'function') {
+            this.onKeyMouseUpCallback = callback;
         } else {
             throw new Error("Callback is not a function");
         }


### PR DESCRIPTION
Best regards from from https://pianoml.org,  👽
This is a non-disruptive contribution aimed at making the library more suitable  music education web apps like PianoML, while benefiting all user, Make the piano keyboard visually more customizable without changing core logic:
 
- index.d.ts extended so TypeScript users get proper autocompletion and type checking for the new options
- Improved interactivity / event handling: added dedicated callbacks for finer-grained events, setOnKeyKeyDown(callback), setOnKeyUp(callback)
- Added export type Keyboard = InstanceType<typeof Keyboard>; for cleaner usage in TS projects.
- Mark central DO (C4) with a grey circle at the padded bottom of the SVG note
- add  options.keyHeight for tuning given a range of 88/76/43 or less key ranges

https://pianoml.org is a browser-based piano learning tool that imports sheet music (MusicXML/MIDI/PDF), generates scales, gives real-time feedback when playing via MIDI keyboard, and supports focused practice (loop measures, separate hands, etc.). It almost certainly embeds an on-screen piano keyboard for visual reference, note highlighting, or click-to-play features.The original pianokeys co — especially on various screen size,, and regarding events, needed to be extended. This PR add flexible geometry parameters, tuned defaults for better UX in educational contexts, try to documented them properly, and added more precise mouse event hooks.







